### PR TITLE
fix: provide artifact-coverage-directory input to sonar_cloud_scan_python workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,4 +41,5 @@ jobs:
     with:
       python-version: '3.13'
       sonar-qualitygate-wait: true
+      artifact-coverage-directory: '.'
     secrets: inherit


### PR DESCRIPTION
## Problem

The `security-checks` job calls `xoanmm/actions/.github/workflows/sonar_cloud_scan_python.yml` without providing the `artifact-coverage-directory` input, which is declared as `required: true` in the reusable workflow.

This caused:
```
The workflow is not valid. .github/workflows/ci.yaml (Line: 40, Col: 11):
Input artifact-coverage-directory is required, but not provided while calling.
```

## Fix

Added `artifact-coverage-directory: '.'` to the `with:` block of the `security-checks` job, matching the default value defined in the reusable workflow.

## Related

A companion PR in [xoanmm/actions](https://github.com/xoanmm/actions) fixes the root cause by changing `required: true` → `required: false` on that input.